### PR TITLE
fix: remove stale action references in RFI-confirm-EntraID-risky-user…

### DIFF
--- a/Solutions/Recorded Future Identity/Playbooks/v3.0/RFI-confirm-EntraID-risky-user/azuredeploy.json
+++ b/Solutions/Recorded Future Identity/Playbooks/v3.0/RFI-confirm-EntraID-risky-user/azuredeploy.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.2.0.0",
+    "contentVersion": "1.2.1.0",
     "metadata": {
         "title": "RFI-confirm-EntraID-risky-user",
         "description": "This playbook confirms compromise of users deemed 'high risk' by EntraID.",
-        "lastUpdateTime": "2025-04-29T14:25:00.000Z",
+        "lastUpdateTime": "2026-05-04T00:00:00.000Z",
         "entities": [],
         "tags": ["Identity protection"],
         "support": {
@@ -28,6 +28,11 @@
                 "version": "1.2",
                 "title": "Improved stability",
                 "notes": [ "Removed Get Risky User action due to instability" ]
+            },
+            {
+                "version": "1.2.1",
+                "title": "Bug fix",
+                "notes": [ "Removed stale references to deleted 'Check_if_AD_Identity_Protection_risky_users_list_contains_the_user' action that caused ARM template deploy failure" ]
             }
         ]
     },
@@ -48,7 +53,7 @@
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
             "tags": {
-                "hidden-SentinelTemplateVersion": "1.2"
+                "hidden-SentinelTemplateVersion": "1.2.1"
             },
             "dependsOn": [
 				"[resourceId('Microsoft.Web/connections', variables('EntraIDConnectionName'))]",
@@ -200,7 +205,6 @@
                             "inputs": {
                                 "body": {
                                     "data": {
-                                        "active_directory_identity_protection_results_for_risky_user": "@body('Check_if_AD_Identity_Protection_risky_users_list_contains_the_user')",
                                         "parameters_passed": {
                                             "active_directory_domain": "@triggerBody()?['active_directory_domain']",
                                             "risky_user_email": "@triggerBody()?['risky_user_email']"
@@ -218,10 +222,6 @@
                                     "properties": {
                                         "data": {
                                             "properties": {
-                                                "active_directory_identity_protection_results_for_risky_user": {
-                                                    "properties": {},
-                                                    "type": "object"
-                                                },
                                                 "parameters_passed": {
                                                     "properties": {
                                                         "active_directory_domain": {
@@ -321,7 +321,6 @@
                             "inputs": {
                                 "body": {
                                     "data": {
-                                        "active_directory_identity_protection_results_for_risky_user": "@body('Check_if_AD_Identity_Protection_risky_users_list_contains_the_user')",
                                         "parameters_passed": {
                                             "active_directory_domain": "@triggerBody()?['active_directory_domain']",
                                             "risky_user_email": "@triggerBody()?['risky_user_email']"
@@ -338,10 +337,6 @@
                                     "properties": {
                                         "data": {
                                             "properties": {
-                                                "active_directory_identity_protection_results_for_risky_user": {
-                                                    "properties": {},
-                                                    "type": "object"
-                                                },
                                                 "parameters_passed": {
                                                     "properties": {
                                                         "active_directory_domain": {


### PR DESCRIPTION
## Summary

- Fixes RFPD-107446: ARM template for `RFI-confirm-EntraID-risky-user` fails validation at deploy time with `InvalidTemplate`
- Root cause: `Check_if_AD_Identity_Protection_risky_users_list_contains_the_user` was deleted in v1.2 (for instability), but `@body()` references to it were left in two response actions
- Removes the stale `active_directory_identity_protection_results_for_risky_user` field and its schema entry from both `Response_-_Failed_to_confirm_user_at_risk_is_compromised` and `Response_-_Successfully_confirmed_user_at_risk_is_indeed_compromised`
- Bumps template version to 1.2.1

## Test plan

- [ ] ARM template validates with `az deployment group validate` (confirmed locally — no errors)
- [ ] No remaining `@body('Check_if_AD_Identity_Protection_risky_users_list_contains_the_user')` references in the template
- [ ] JSON is well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)