### PR TITLE
docs: fix default sandbox region in RF Sandboxing readme

### DIFF
--- a/Solutions/Recorded Future/Playbooks/Sandboxing/readme.md
+++ b/Solutions/Recorded Future/Playbooks/Sandboxing/readme.md
@@ -10,7 +10,7 @@ If you use the Enterprise Sandbox, you need to provide an additional key `Enterp
 Refer to [Recorded Future API Key](../readme.md#recorded-future-api-key) for guidance on obtaining and using the necessary API keys.
 
 ### Configure Sandbox region
-Recorded Future has multiple sandbox regions available. By default, the playbooks will submit to the `us` sandbox.
+Recorded Future has multiple sandbox regions available. By default, the playbooks will submit to the `eu` sandbox.
 But you can configure this in the logic apps by changing the parameter `SandboxRegion` to one of the following values:
 * `eu` (default)
 * `us`


### PR DESCRIPTION
## Summary

- Corrects the documented default sandbox region from `us` to `eu` in the RF Sandboxing readme.
- The bullet list already correctly showed `eu (default)`, but the prose above contradicted it.

> AI generated