### PR TITLE
docs: add AGENTS.md with PR guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent Guidelines
+
+## Pull Requests
+
+- All PRs should be opened towards `master-rf` (our internal default branch).
+- All PR descriptions should end with:
+
+  > When PR is ready to be submitted upstream, comment `/upstream-pr` to prepare PR towards Microsoft.


### PR DESCRIPTION
## Summary

- Adds a minimal `AGENTS.md` at the repo root with guidelines for AI agents.
- Specifies that all PRs should target `master-rf` (our internal default branch).
- Specifies that all PR descriptions should end with a note on how to trigger an upstream PR towards Microsoft.

> AI generated

---

> When PR is ready to be submitted upstream, comment `/upstream-pr` to prepare PR towards Microsoft.